### PR TITLE
Update Segment.php

### DIFF
--- a/htdocs/includes/odtphp/Segment.php
+++ b/htdocs/includes/odtphp/Segment.php
@@ -139,6 +139,8 @@ class Segment implements IteratorAggregate, Countable
         }
         $reg = "/\[!--\sBEGIN\s$this->name\s--\](.*)\[!--\sEND\s$this->name\s--\]/sm";
         $this->xmlParsed = preg_replace($reg, '$1', $this->xmlParsed);
+	// Miguel Erill 09704/2017 - Add macro replacement to invoice lines
+        $this->xmlParsed = $this->macroReplace($this->xmlParsed);
         $this->file->open($this->odf->getTmpfile());
         foreach ($this->images as $imageKey => $imageValue) {
 			if ($this->file->getFromName('Pictures/' . $imageValue) === false) {
@@ -151,6 +153,29 @@ class Segment implements IteratorAggregate, Countable
         $this->file->close();
         
         return $this->xmlParsed;
+    }
+   /**
+    * Function to replace macros for invoice short and long month, invoice year
+    * 
+    * Substitution occur when the invoice is generated, not considering the invoice date
+    * so do not (re)generate in a diferent date than the one that the invoice belongs to
+    * Perhaps it would be better to use the invoice issued date but I still do not know
+    * how to get it here
+    *
+    * Miguel Erill 09/04/2017
+    * 
+    * @param	string	$value	String to convert
+    */
+    public function macroReplace($text)
+    {
+        global $langs;
+
+        $patterns=array( '/\[%M\]/','/\[%F\]/','/\[%Y\]/' );
+        $values=array( $langs->trans(date('M')), $langs->trans(date('F')), date('Y') );
+
+        $text=preg_replace($patterns, $values, $text);
+
+	return $text;
     }
     /**
      * Analyse the XML code in order to find children


### PR DESCRIPTION
# New [Add macro replacement to invoice lines]
[Added the op tion to use macro substitution in the Description lines of an invoice. So you can write a description like 'Services for [%F]' and that will be printed as 'Services for January' if the invoie is generated in January.

Current substitutions are limited to short and long month names and long year using the same format specifiers (M, F, Y)]
